### PR TITLE
fix(#32): place ABNF-based root rule assumption on group in the evaluator

### DIFF
--- a/grammar.go
+++ b/grammar.go
@@ -154,8 +154,7 @@ func Parse(input []byte, grammar *Grammar, rootRulename string) ([]*Path, error)
 	outPoss := []*Path{}
 	for _, poss := range possibilites {
 		if poss.End == len(input) {
-			pth := poss.Subpaths[0]
-			pth.MatchRule = rootRulename
+			poss.MatchRule = rootRulename
 			outPoss = append(outPoss, poss)
 		}
 	}
@@ -423,6 +422,7 @@ func lexABNF(input []byte, path *Path) (any, error) {
 	case abnfRulelist.Name:
 		mp := map[string]*Rule{}
 
+		path := path.Subpaths[0]
 		sub := path.Subpaths[0]
 		for i := 0; i < len(path.Subpaths); i++ {
 			// Only work on rules (i.e. skip empty lines)

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -202,3 +202,30 @@ func Test_U_ABNFParseItself(t *testing.T) {
 	assert.NotNil(sol)
 	assert.Nil(err)
 }
+
+func Test_U_ParseRootNonGroup(t *testing.T) {
+	// Issue #32 use case is a root rule that does not start
+	// with a group as its first root alternation element.
+	assert := assert.New(t)
+
+	// First we build our grammar
+	g, err := goabnf.ParseABNF(platypusAbnf)
+	if !assert.Nil(err) {
+		return
+	}
+
+	// Then we consider an input, valid according to our grammar.
+	input := []byte("a")
+	p, err := goabnf.Parse(input, g, "b")
+	if !assert.Nil(err) {
+		return
+	}
+
+	// Then we make sure there is only 1 possibility, and all
+	// subpaths have the proper name.
+	if !assert.Len(p, 1) {
+		return
+	}
+	assert.Equal("b", p[0].MatchRule)
+	assert.Equal("a", p[0].Subpaths[0].MatchRule)
+}


### PR DESCRIPTION
Fix #32 