### PR TITLE
Allow including core rules

### DIFF
--- a/grammar.go
+++ b/grammar.go
@@ -2,6 +2,7 @@ package goabnf
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -452,8 +453,15 @@ func lexABNF(input []byte, path *Path) (any, error) {
 				switch definedAs {
 				case "=":
 					if rule := GetRule(rl.Name, mp); rule != nil {
-						return nil, &ErrDuplicatedRule{
-							Rulename: rl.Name,
+						c, ok := coreRules[rl.Name]
+						if !ok {
+							return nil, &ErrDuplicatedRule{
+								Rulename: rl.Name,
+							}
+						}
+						if !reflect.DeepEqual(rl.Alternation, c.Alternation) {
+							return nil, fmt.Errorf("core rule %q redefined with different definition: %q != %q",
+								rl.Name, c.Alternation, rl.Alternation)
 						}
 					}
 					mp[rl.Name] = &rl

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -192,6 +192,24 @@ var testsParseAbnf = map[string]struct {
 		Validate:  true,
 		ExpectErr: true,
 	},
+
+	"redef-core": {
+		Input:     []byte("DIGIT = %x30-39\r\n"),
+		Validate:  true,
+		ExpectErr: false,
+	},
+	"redef-core-different-base": {
+		// TODO: currently fails, but probably shouldn't? Should be fixed by
+		// https://github.com/pandatix/go-abnf/pull/107
+		Input:     []byte("DIGIT = %d48-58\r\n"),
+		Validate:  true,
+		ExpectErr: true,
+	},
+	"redef-core-different-different": {
+		Input:     []byte("DIGIT = %x30-40\r\n"),
+		Validate:  true,
+		ExpectErr: true,
+	},
 }
 
 func Test_U_ParseABNF(t *testing.T) {


### PR DESCRIPTION
Do throw an error if the definition is different from what's expected.

Fixes #106