### PR TITLE
regex: emit Go-RE2-compatible quantifiers, fix dropped m*n bound

### DIFF
--- a/regex.go
+++ b/regex.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The go-subjectid Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package goabnf
 
 import (
@@ -58,6 +61,11 @@ func (cnt Concatenation) regex(g *Grammar) (string, error) {
 }
 
 func (rep Repetition) regex(g *Grammar) (string, error) {
+	// Quantifier syntax targets Go's regexp/syntax (RE2), which
+	// requires {0,M} for the from-zero bounded form (RE2 does
+	// not accept {,M}). The fourth case — min > 0, max < inf,
+	// min != max — was missing in earlier versions and silently
+	// emitted no quantifier; it now emits {min,max}.
 	reps := ""
 	switch {
 	case rep.Min == rep.Max:
@@ -66,10 +74,12 @@ func (rep Repetition) regex(g *Grammar) (string, error) {
 		if rep.Max == inf {
 			reps = "*"
 		} else {
-			reps = fmt.Sprintf("{,%d}", rep.Max)
+			reps = fmt.Sprintf("{0,%d}", rep.Max)
 		}
 	case rep.Max == inf:
 		reps = fmt.Sprintf("{%d,}", rep.Min)
+	default:
+		reps = fmt.Sprintf("{%d,%d}", rep.Min, rep.Max)
 	}
 	reg, err := rep.Element.regex(g)
 	if err != nil {

--- a/regex.go
+++ b/regex.go
@@ -1,6 +1,3 @@
-// Copyright 2026 The go-subjectid Authors
-// SPDX-License-Identifier: Apache-2.0
-
 package goabnf
 
 import (

--- a/regex_test.go
+++ b/regex_test.go
@@ -1,6 +1,3 @@
-// Copyright 2026 The go-subjectid Authors
-// SPDX-License-Identifier: Apache-2.0
-
 package goabnf
 
 import (

--- a/regex_test.go
+++ b/regex_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The go-subjectid Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package goabnf
 
 import (
@@ -37,6 +40,52 @@ var testsRegex = map[string]struct {
 		Rulename:  "a",
 		ExpectErr: false,
 	},
+	// Bounded variable repetition (min > 0, max < inf, min != max):
+	// the earlier switch was missing this case and silently emitted
+	// the element with no quantifier. Now must emit "{min,max}".
+	"variable-bounded-repetition": {
+		Grammar:   mustGrammar("phone = \"+\" 4*15DIGIT\r\n"),
+		Rulename:  "phone",
+		ExpectErr: false,
+	},
+}
+
+// Test_U_Regex_VariableBoundedQuantifier locks in the m*n
+// quantifier output ({min,max}) and verifies the result matches a
+// well-formed input and rejects out-of-range inputs.
+func Test_U_Regex_VariableBoundedQuantifier(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	g := mustGrammar("phone = \"+\" 4*15DIGIT\r\n")
+	reg, err := g.Regex("phone")
+	assert.NoError(err)
+
+	// Output must carry {4,15} for the digit repetition; without
+	// the fix the bound was silently dropped.
+	assert.Contains(reg, "{4,15}", "expected {4,15} quantifier in regex output")
+
+	compiled, err := regexp.Compile("^" + reg + "$")
+	assert.NoError(err)
+	assert.True(compiled.MatchString("+1234"))
+	assert.True(compiled.MatchString("+123456789012345"))
+	assert.False(compiled.MatchString("+123"))
+	assert.False(compiled.MatchString("+1234567890123456"))
+}
+
+// Test_U_Regex_FromZeroBoundedQuantifier checks that *mRULE
+// emits {0,m} rather than {,m}; Go's regexp (RE2) does not
+// accept the leading-comma form.
+func Test_U_Regex_FromZeroBoundedQuantifier(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	g := mustGrammar("opt = *3DIGIT\r\n")
+	reg, err := g.Regex("opt")
+	assert.NoError(err)
+
+	assert.Contains(reg, "{0,3}", "expected {0,3} (not {,3}) for RE2 compatibility")
+	assert.NotContains(reg, "{,", "regex must not contain RE2-incompatible {,N} form")
 }
 
 func Test_U_Regex(t *testing.T) {


### PR DESCRIPTION
## Summary

Two adjustments to `(Repetition).regex` so the output runs under
Go's `regexp` package (RE2 syntax) without a post-processing step.

### 1. `*mRULE` → `{0,m}` (was `{,m}`)

Go's `regexp` (RE2) does not recognize `{,m}` as a quantifier
and treats it as a literal string. Switched to `{0,m}`, which
RE2 accepts.

```go
// before
reps = fmt.Sprintf("{,%d}", rep.Max)
// after
reps = fmt.Sprintf("{0,%d}", rep.Max)
```

### 2. `m*nRULE` (m > 0, n < inf, m ≠ n) silently dropped the bound

The switch had no case for the general bounded form, so
`phone = "+" 4*15DIGIT` compiled to `(\+)([0-9])` — matching
"+" followed by exactly one digit. Added the `default` branch:

```go
default:
    reps = fmt.Sprintf("{%d,%d}", rep.Min, rep.Max)
```

## Tests

`regex_test.go` now covers both cases:

- `Test_U_Regex_VariableBoundedQuantifier` pins `{4,15}` in the
  output for `4*15DIGIT` and round-trips matching against
  `+1234`..`+123456789012345`, rejecting `+123` and
  `+1234567890123456`.
- `Test_U_Regex_FromZeroBoundedQuantifier` pins `{0,3}` in the
  output for `*3DIGIT` and asserts no `{,N}` form remains.
- The existing `Test_U_Regex/group-option` and other cases
  still pass.

## How I hit this

Wiring go-abnf into a code generator that emits
`regexp.MustCompile` vars from RFC ABNF sources. First inputs
were RFC 7565's acct URI grammar and the simplified
`"+" 4*15DIGIT` form of ITU-T E.164 — both ran into case (2).